### PR TITLE
Configuring the action to perform on encountering a warn-condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,19 @@ It's a work in progress.
 
 Add it as a compiler plugin in your project, or run `sbt console` in this project to see it in action.
 
+The plugin can optionally use a properties file (provided with `-P
+linter:config:/path/to/it` on the scalac command line) that allows
+controlling the action taken by the plugin either globally or on a
+per-warning basis. The default action is `warn` and may be changed to
+`no_action` or `error` by setting the `default_action` value in the
+properties file.  The default can be overridden on a per-check basis
+with any of those three options.
+
 ## Currently suported warnings
 
 ### Unsafe `==`
+
+The configuration property is `check.unsafe_equals`.
 
     scala> Nil == None
     <console>:29: warning: Comparing with == on instances of different types (object Nil, object None) will probably return false.
@@ -19,6 +29,8 @@ Add it as a compiler plugin in your project, or run `sbt console` in this projec
                       ^
 
 ### Unsafe `contains`
+
+The configuration property is `check.unsafe_contains`.
 
     scala> List(1, 2, 3).contains("4")
     <console>:29: warning: SeqLike[Int].contains(java.lang.String) will probably return false.
@@ -28,12 +40,16 @@ Add it as a compiler plugin in your project, or run `sbt console` in this projec
 
 ### Wildcard import from `scala.collection.JavaConversions`
 
+The configuration property is `check.java_conversions`.
+
     scala> import scala.collection.JavaConversions._
     <console>:29: warning: Conversions in scala.collection.JavaConversions._ are dangerous.
            import scala.collection.JavaConversions._
                                    ^
 
 ### Calling `Option#get`
+
+The configuration property is `check.option_get`.
 
     scala> Option(1).get
     <console>:29: warning: Calling .get on Option will throw an exception if the Option is None.
@@ -43,8 +59,6 @@ Add it as a compiler plugin in your project, or run `sbt console` in this projec
 ## Future Work
 
 * Add more warnings
-* Pick and choose which warnings you want
-* Choose whether they should be warnings or errors
 
 ### Ideas for new warnings
 

--- a/src/main/scala/JavaConversions.scala
+++ b/src/main/scala/JavaConversions.scala
@@ -1,0 +1,19 @@
+package com.foursquare.lint
+
+import scala.tools.nsc.Global
+
+class JavaConversions(g: Global) extends LinterAction(g, Warnings.JavaConversions) {
+  import global._
+
+  val JavaConversionsModule: Symbol = definitions.getModule("scala.collection.JavaConversions")
+
+  def isGlobalImport(selector: ImportSelector): Boolean = {
+    selector.name == nme.WILDCARD && selector.renamePos == -1
+  }
+
+  val action: PartialFunction[Tree, (Position, String)] = {
+    case Import(pkg, selectors)
+        if pkg.symbol == JavaConversionsModule && selectors.exists(isGlobalImport) =>
+      (pkg.pos, "Conversions in scala.collection.JavaConversions._ are dangerous.")
+  }
+}

--- a/src/main/scala/LinterAction.scala
+++ b/src/main/scala/LinterAction.scala
@@ -1,0 +1,15 @@
+package com.foursquare.lint
+
+import scala.tools.nsc.Global
+
+abstract class LinterAction(val global: Global, val warning: Warnings.Warning) {
+  import global._
+
+  def action: PartialFunction[Tree, (Position, String)]
+
+  // Utility predicates that are used by multiple warning types
+
+  def methodImplements(method: Symbol, target: Symbol): Boolean = {
+    method == target || method.allOverriddenSymbols.contains(target)
+  }
+}

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -82,9 +82,16 @@ class LinterPlugin(val global: Global) extends Plugin {
     val Warn = underscoreify(Actions.Warn.toString)
     val Error = underscoreify(Actions.Error.toString)
 
+    val defaultAction = props.getProperty("default_action", Warn) match {
+      case action@(NoAction|Warn|Error) => action
+      case other =>
+        error("Unknown action for default_action: " + other)
+        return
+    }
+
     warningActions =
       Warnings.values.foldLeft(Map.empty[Warnings.Warning, Actions.Action]) { (warningConfig, warning) =>
-        val action = props.getProperty("check." + underscoreify(warning.toString), Warn) match {
+        val action = props.getProperty("check." + underscoreify(warning.toString), defaultAction) match {
           case NoAction => Actions.NoAction
           case Warn => Actions.Warn
           case Error => Actions.Error

--- a/src/main/scala/OptionGet.scala
+++ b/src/main/scala/OptionGet.scala
@@ -1,0 +1,16 @@
+package com.foursquare.lint
+
+import scala.tools.nsc.Global
+
+class OptionGet(g: Global) extends LinterAction(g, Warnings.OptionGet) {
+  import global._
+
+  import definitions.OptionClass
+  val OptionGet: Symbol = OptionClass.info.member(nme.get)
+
+  val action: PartialFunction[Tree, (Position, String)] = {
+    case get @ Select(_, nme.get)
+        if methodImplements(get.symbol, OptionGet) && !get.pos.source.path.contains("src/test") =>
+      (get.pos, "Calling .get on Option will throw an exception if the Option is None.")
+  }
+}

--- a/src/main/scala/UnsafeContains.scala
+++ b/src/main/scala/UnsafeContains.scala
@@ -1,0 +1,21 @@
+package com.foursquare.lint
+
+import scala.tools.nsc.Global
+
+class UnsafeContains(g: Global) extends LinterAction(g, Warnings.UnsafeContains) {
+  import global._
+
+  val SeqLikeClass: Symbol = definitions.getClass("scala.collection.SeqLike")
+  val SeqLikeContains: Symbol = SeqLikeClass.info.member(newTermName("contains"))
+
+  def SeqMemberType(seenFrom: Type): Type = {
+    SeqLikeClass.tpe.typeArgs.head.asSeenFrom(seenFrom, SeqLikeClass)
+  }
+
+  val action: PartialFunction[Tree, (Position, String)] = {
+    case Apply(contains @ Select(seq, _), List(target))
+        if methodImplements(contains.symbol, SeqLikeContains) && !(target.tpe <:< SeqMemberType(seq.tpe)) =>
+      val warnMsg = "SeqLike[%s].contains(%s) will probably return false."
+      (contains.pos, warnMsg.format(SeqMemberType(seq.tpe), target.tpe.widen))
+  }
+}

--- a/src/main/scala/UnsafeEquals.scala
+++ b/src/main/scala/UnsafeEquals.scala
@@ -1,0 +1,20 @@
+package com.foursquare.lint
+
+import scala.tools.nsc.Global
+
+class UnsafeEquals(g: Global) extends LinterAction(g, Warnings.UnsafeEquals) {
+  import global._
+  import definitions.Object_==
+
+  def isSubtype(x: Tree, y: Tree): Boolean = {
+    x.tpe.widen <:< y.tpe.widen
+  }
+
+  val action: PartialFunction[Tree, (Position, String)] = {
+    case Apply(eqeq @ Select(lhs, nme.EQ), List(rhs))
+        if methodImplements(eqeq.symbol, Object_==) && !(isSubtype(lhs, rhs) || isSubtype(rhs, lhs)) =>
+      val warnMsg = "Comparing with == on instances of different types (%s, %s) will probably return false."
+      (eqeq.pos, warnMsg.format(lhs.tpe.widen, rhs.tpe.widen))
+  }
+}
+

--- a/src/main/scala/Warnings.scala
+++ b/src/main/scala/Warnings.scala
@@ -1,0 +1,9 @@
+package com.foursquare.lint
+
+object Warnings extends Enumeration {
+  type Warning = Value
+  val JavaConversions,
+  OptionGet,
+  UnsafeContains,
+  UnsafeEquals = Value
+}

--- a/src/test/resources/testprops/allbutjavaconversionserror.properties
+++ b/src/test/resources/testprops/allbutjavaconversionserror.properties
@@ -1,0 +1,3 @@
+check.option_get = error
+check.unsafe_contains = error
+check.unsafe_equals = error

--- a/src/test/resources/testprops/allbutjavaconversionsoff.properties
+++ b/src/test/resources/testprops/allbutjavaconversionsoff.properties
@@ -1,0 +1,3 @@
+check.option_get = false
+check.unsafe_contains = false
+check.unsafe_equals = false

--- a/src/test/resources/testprops/allbutjavaconversionsoff.properties
+++ b/src/test/resources/testprops/allbutjavaconversionsoff.properties
@@ -1,3 +1,3 @@
-check.option_get = false
-check.unsafe_contains = false
-check.unsafe_equals = false
+check.option_get = no_action
+check.unsafe_contains = no_action
+check.unsafe_equals = no_action

--- a/src/test/resources/testprops/allbutoptiongeterror.properties
+++ b/src/test/resources/testprops/allbutoptiongeterror.properties
@@ -1,0 +1,3 @@
+check.java_conversions = error
+check.unsafe_contains = error
+check.unsafe_equals = error

--- a/src/test/resources/testprops/allbutoptiongetoff.properties
+++ b/src/test/resources/testprops/allbutoptiongetoff.properties
@@ -1,0 +1,3 @@
+check.java_conversions = false
+check.unsafe_contains = false
+check.unsafe_equals = false

--- a/src/test/resources/testprops/allbutoptiongetoff.properties
+++ b/src/test/resources/testprops/allbutoptiongetoff.properties
@@ -1,3 +1,3 @@
-check.java_conversions = false
-check.unsafe_contains = false
-check.unsafe_equals = false
+check.java_conversions = no_action
+check.unsafe_contains = no_action
+check.unsafe_equals = no_action

--- a/src/test/resources/testprops/allbutunsafecontainserror.properties
+++ b/src/test/resources/testprops/allbutunsafecontainserror.properties
@@ -1,0 +1,3 @@
+check.java_conversions = error
+check.option_get = error
+check.unsafe_equals = error

--- a/src/test/resources/testprops/allbutunsafecontainsoff.properties
+++ b/src/test/resources/testprops/allbutunsafecontainsoff.properties
@@ -1,0 +1,3 @@
+check.java_conversions = false
+check.option_get = false
+check.unsafe_equals = false

--- a/src/test/resources/testprops/allbutunsafecontainsoff.properties
+++ b/src/test/resources/testprops/allbutunsafecontainsoff.properties
@@ -1,3 +1,3 @@
-check.java_conversions = false
-check.option_get = false
-check.unsafe_equals = false
+check.java_conversions = no_action
+check.option_get = no_action
+check.unsafe_equals = no_action

--- a/src/test/resources/testprops/allbutunsafeequalserror.properties
+++ b/src/test/resources/testprops/allbutunsafeequalserror.properties
@@ -1,0 +1,3 @@
+check.java_conversions = error
+check.option_get = error
+check.unsafe_contains = error

--- a/src/test/resources/testprops/allbutunsafeequalsoff.properties
+++ b/src/test/resources/testprops/allbutunsafeequalsoff.properties
@@ -1,3 +1,3 @@
-check.java_conversions = false
-check.option_get = false
-check.unsafe_contains = false
+check.java_conversions = no_action
+check.option_get = no_action
+check.unsafe_contains = no_action

--- a/src/test/resources/testprops/allbutunsafeequalsoff.properties
+++ b/src/test/resources/testprops/allbutunsafeequalsoff.properties
@@ -1,0 +1,3 @@
+check.java_conversions = false
+check.option_get = false
+check.unsafe_contains = false

--- a/src/test/resources/testprops/allerror.properties
+++ b/src/test/resources/testprops/allerror.properties
@@ -1,0 +1,4 @@
+check.java_conversions = error
+check.option_get = error
+check.unsafe_contains = error
+check.unsafe_equals = error

--- a/src/test/resources/testprops/alloff.properties
+++ b/src/test/resources/testprops/alloff.properties
@@ -1,0 +1,4 @@
+check.java_conversions = false
+check.option_get = false
+check.unsafe_contains = false
+check.unsafe_equals = false

--- a/src/test/resources/testprops/alloff.properties
+++ b/src/test/resources/testprops/alloff.properties
@@ -1,4 +1,4 @@
-check.java_conversions = false
-check.option_get = false
-check.unsafe_contains = false
-check.unsafe_equals = false
+check.java_conversions = no_action
+check.option_get = no_action
+check.unsafe_contains = no_action
+check.unsafe_equals = no_action

--- a/src/test/resources/testprops/defaulterror.properties
+++ b/src/test/resources/testprops/defaulterror.properties
@@ -1,0 +1,1 @@
+default_action = error

--- a/src/test/resources/testprops/defaultnoaction.properties
+++ b/src/test/resources/testprops/defaultnoaction.properties
@@ -1,0 +1,1 @@
+default_action = no_action

--- a/src/test/resources/testprops/javaconversionserror.properties
+++ b/src/test/resources/testprops/javaconversionserror.properties
@@ -1,0 +1,1 @@
+check.java_conversions = error

--- a/src/test/resources/testprops/javaconversionsoff.properties
+++ b/src/test/resources/testprops/javaconversionsoff.properties
@@ -1,1 +1,1 @@
-check.java_conversions = false
+check.java_conversions = no_action

--- a/src/test/resources/testprops/javaconversionsoff.properties
+++ b/src/test/resources/testprops/javaconversionsoff.properties
@@ -1,0 +1,1 @@
+check.java_conversions = false

--- a/src/test/resources/testprops/optiongeterror.properties
+++ b/src/test/resources/testprops/optiongeterror.properties
@@ -1,0 +1,1 @@
+check.option_get = error

--- a/src/test/resources/testprops/optiongetoff.properties
+++ b/src/test/resources/testprops/optiongetoff.properties
@@ -1,1 +1,1 @@
-check.option_get = false
+check.option_get = no_action

--- a/src/test/resources/testprops/optiongetoff.properties
+++ b/src/test/resources/testprops/optiongetoff.properties
@@ -1,0 +1,1 @@
+check.option_get = false

--- a/src/test/resources/testprops/unsafecontainserror.properties
+++ b/src/test/resources/testprops/unsafecontainserror.properties
@@ -1,0 +1,1 @@
+check.unsafe_contains = error

--- a/src/test/resources/testprops/unsafecontainsoff.properties
+++ b/src/test/resources/testprops/unsafecontainsoff.properties
@@ -1,0 +1,1 @@
+check.unsafe_contains = false

--- a/src/test/resources/testprops/unsafecontainsoff.properties
+++ b/src/test/resources/testprops/unsafecontainsoff.properties
@@ -1,1 +1,1 @@
-check.unsafe_contains = false
+check.unsafe_contains = no_action

--- a/src/test/resources/testprops/unsafeequalserror.properties
+++ b/src/test/resources/testprops/unsafeequalserror.properties
@@ -1,0 +1,1 @@
+check.unsafe_equals = error

--- a/src/test/resources/testprops/unsafeequalsoff.properties
+++ b/src/test/resources/testprops/unsafeequalsoff.properties
@@ -1,1 +1,1 @@
-check.unsafe_equals = false
+check.unsafe_equals = no_action

--- a/src/test/resources/testprops/unsafeequalsoff.properties
+++ b/src/test/resources/testprops/unsafeequalsoff.properties
@@ -1,0 +1,1 @@
+check.unsafe_equals = false

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -181,4 +181,14 @@ class LinterPluginTest extends SpecsMatchers {
       }""", options = options)
     }
   }
+
+  @Test
+  def testDefaultNoAction(): Unit = {
+    check("Nil == None", None, List("config:testprops/defaultnoaction.properties"))
+  }
+
+  @Test
+  def testDefaultError(): Unit = {
+    check("Nil == None", Some("error: Comparing with =="), List("config:testprops/defaulterror.properties"))
+  }
 }


### PR DESCRIPTION
I've added an option to pass in a properties file that allows the plugin's user to define the action to take on encountering a construct that it wants to warn about. The action (one of "no_action", "warn", or "error") is configurable both globally and on a per-warning-type basis.  The last commit in this series breaks the individual checks out into their own classes to serve as a base for growing the set of checks without bloating LinterPlugin.scala itself without bound.

I'm not super happy with the tests. They're pretty comprehensive, but in order to keep the amount of repetitive code down, I've made each individual test use a helper that invokes the actual test code multiple times with various options for testing each codepath. It ends up being memory intensive (many differently-configured Scala compilers instantiated!), not very fast, and honestly not very unit-testy. Still, it works.
