### PR TITLE
Hey - this is just a "getting my feet wet" commit; I'm going to try to add some external configuration of which checks to run next...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/target/

--- a/README.md
+++ b/README.md
@@ -3,11 +3,19 @@
 This is a compiler plugin that adds additional lint checks to protect against sharp corners
 in the Scala compiler and standard libraries.
 
-It's a work in progress.
+It's a work in progress.  For an overview of writing compiler plugins, see http://www.scala-lang.org/node/140
 
 ## Usage
 
-Add it as a compiler plugin in your project, or run `sbt console` in this project to see it in action.
+Add it as a compiler plugin in your project by editing your build.sbt file.  For example, once published:
+
+    addCompilerPlugin("com.foursquare.lint" %% "linter" % "x.y.z")
+
+Or, until published:
+
+    scalacOptions += "-Xplugin:..path-to-jar../linter.jar"
+
+Optionally, run `sbt console` in this project to see it in action.
 
 ## Currently suported warnings
 
@@ -33,6 +41,13 @@ Add it as a compiler plugin in your project, or run `sbt console` in this projec
            import scala.collection.JavaConversions._
                                    ^
 
+### Any and all wildcard imports
+
+    scala> import scala.collection.JavaConversions._
+    <console>:10: warning: Wildcard imports should be avoided.
+           import scala.reflect.generic._
+
+
 ### Calling `Option#get`
 
     scala> Option(1).get
@@ -50,7 +65,8 @@ Add it as a compiler plugin in your project, or run `sbt console` in this projec
 
 Feel free to implement these, or add your own ideas. Pull requests welcome!
 
-* Warn on wildcard imports (either all with whitelist, or blacklist)
+* Modularize the wildcard import warnings like the "Avoid Star Import" configuration of checkstyle
+ (http://checkstyle.sourceforge.net/config_imports.html)
 * Require explicit `override` whenever a method is being overwritten
 * Implicit methods should always have explicit return types
 * Expressions spanning multiple lines should be enclosed in parentheses

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -65,7 +65,7 @@ class LinterPlugin(val global: Global) extends Plugin {
       def isGlobalImport(selector: ImportSelector): Boolean = {
         selector.name == nme.WILDCARD && selector.renamePos == -1
       }
-
+      
       override def traverse(tree: Tree): Unit = tree match {
         case Apply(eqeq @ Select(lhs, nme.EQ), List(rhs))
             if methodImplements(eqeq.symbol, Object_==) && !(isSubtype(lhs, rhs) || isSubtype(rhs, lhs)) =>
@@ -75,6 +75,10 @@ class LinterPlugin(val global: Global) extends Plugin {
         case Import(pkg, selectors)
             if pkg.symbol == JavaConversionsModule && selectors.exists(isGlobalImport) =>
           unit.warning(pkg.pos, "Conversions in scala.collection.JavaConversions._ are dangerous.")
+        
+        case Import(pkg, selectors)
+            if selectors.exists(isGlobalImport) =>
+          unit.warning(pkg.pos, "Wildcard imports should be avoided.  Favor import selector clauses.")
 
         case Apply(contains @ Select(seq, _), List(target))
             if methodImplements(contains.symbol, SeqLikeContains) && !(target.tpe <:< SeqMemberType(seq.tpe)) =>

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -111,6 +111,13 @@ class LinterPluginTest extends SpecsMatchers {
 
     check("import scala.collection.JavaConversions._;", msg)
   }
+  
+  @Test
+  def testAnyWildcardImport(): Unit = {
+    val msg = Some("Wildcard imports should be avoided.  Favor import selector clauses.")
+    
+    check("import org.specs._;", msg)
+  }
 
   @Test
   def testUnsafeEquals(): Unit = {


### PR DESCRIPTION
Added some documentation to the README about how to enable the compiler plugin

Added a too-aggressive global check for any wildcard import.  By way of a TODO,
I added a wishlist item in the README to add support for modularization and
configuration of the different lint checks, kind of like Java's checkstyle plugin
has

Added "target/" to .gitignore
