### PR TITLE
Extern config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Or, until published:
 
 Optionally, run `sbt console` in this project to see it in action.
 
-## Currently suported warnings
+## Currently supported warnings
+
+Note: for configuration documentation, unless otherwise stated, any "checkEnabled" configuration option
+is one of {"true", "false"} and any severity configuration option is one of {"warn", "error"}.
+Configuration documentation examples show the default settings that ship with this linter library.
 
 ### Unsafe `==`
 
@@ -26,12 +30,20 @@ Optionally, run `sbt console` in this project to see it in action.
                   Nil == None
                       ^
 
+    Configuration:
+        linter.eqeq.checkEnabled=true
+        linter.eqeq.severity=error
+
 ### Unsafe `contains`
 
     scala> List(1, 2, 3).contains("4")
     <console>:29: warning: SeqLike[Int].contains(java.lang.String) will probably return false.
                   List(1, 2, 3).contains("4")
                                 ^
+
+    Configuration:
+        linter.seq.contains.checkEnabled=true
+        linter.seq.contains.severity=warn
 
 
 ### Wildcard import from `scala.collection.JavaConversions`
@@ -41,12 +53,20 @@ Optionally, run `sbt console` in this project to see it in action.
            import scala.collection.JavaConversions._
                                    ^
 
+    Configuration:
+        None at present
+
 ### Any and all wildcard imports
 
     scala> import scala.collection.JavaConversions._
     <console>:10: warning: Wildcard imports should be avoided.
            import scala.reflect.generic._
 
+
+    Configuration:
+        linter.package.wildcard.whitelist.checkEnabled=true
+        linter.package.wildcard.whitelist.severity=warn
+        linter.package.wildcard.whitelist.packages=[]
 
 ### Calling `Option#get`
 
@@ -55,11 +75,24 @@ Optionally, run `sbt console` in this project to see it in action.
                   Option(1).get
                             ^
 
+    Configuration:
+        linter.option.get.checkEnabled=true
+        linter.option.get.severity=warn
+
+## Configuring Linter
+
+Linter is configured with the com.typesafe.config library (https://github.com/typesafehub/config)
+
+In your application, you can override any of the configuration options from these locations (in priority-respecting order):
+* system properties
+* application.conf available on the classpath
+* application.json available on the classpath
+* application.properties available on the classpath
+
 ## Future Work
 
 * Add more warnings
-* Pick and choose which warnings you want
-* Choose whether they should be warnings or errors
+* Support "blacklist"ing imports and re-write the scala.collection.JavaCollections check with that mechanism
 
 ### Ideas for new warnings
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
 libraryDependencies <++= (scalaVersion) { (scalaVer) =>
   Seq(
     "org.scala-lang"           % "scala-compiler"  % scalaVer,
+    "com.typesafe"             % "config"          % "0.5.0",
     "org.scala-tools.testing" %% "specs"           % "1.6.9"  % "test" withSources(),
     "junit"                    % "junit"           % "4.8.2"  % "test" withSources(),
     "com.novocode"             % "junit-interface" % "0.7"    % "test"
   )
 }
 
-scalacOptions in console in Compile <+= (packageBin in Compile) map { pluginJar =>
-  "-Xplugin:"+pluginJar
+scalacOptions in console in Compile <++= (packageBin in Compile, managedClasspath in Compile) map { (pluginJar, cp) =>
+  val configJar = cp.map(_.data).find(_.toString.contains("config-0.5.0.jar"))
+  Seq("-Xplugin:"+pluginJar) ++ configJar.map("-Xplugin:"+_)
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -5,6 +5,17 @@
 linter {
 
     #
+    # EqualsEquals comparison check on objects of different types
+    #
+    eqeq {
+        # Set to true to have linter check for using "==" on different types
+        checkEnabled=true
+
+        # What level of severity to apply to a failed Lint check (one of "warn" or "error")
+        severity="error"
+    }
+
+    #
     # Wildcard package import control - controls warnings related to importing foo.bar._
     #
     package.wildcard {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -50,10 +50,13 @@ linter {
     }
 
     #
-    # Option.get check  (TODO - is there a broader classification that makes for better organization?)
+    # Option related checks (TODO - is there a broader classification that makes for better organization?)
     #
-    option.get {
-        checkEnabled=true
-        severity=warn
+    option {
+        # Check for calling Option.get 
+        get {
+            checkEnabled=true
+            severity=warn
+        }
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -2,16 +2,16 @@
 # HOCON-standard Linter configuration to control which Lint checks to run 
 # For syntax help, @see https://github.com/typesafehub/config
 #
+# Unless otherwise stated, any "checkEnabled" configuration is one of {"true", "false"}
+# Unless otherwise stated, any "severity" configuration is one of {"warn", "error"}
+#
 linter {
 
     #
     # EqualsEquals comparison check on objects of different types
     #
     eqeq {
-        # Set to true to have linter check for using "==" on different types
         checkEnabled=true
-
-        # What level of severity to apply to a failed Lint check (one of "warn" or "error")
         severity="error"
     }
 
@@ -21,20 +21,17 @@ linter {
     package.wildcard {
 
         whitelist {
-            # Set to true to have linter check and squawk on the use of wildcard imports
             checkEnabled=true
-            
+            severity="warn"
+
             # Comma-separated list of packages to allow for wildcard importing
             packages=[]
-
-            # What level of severity to apply to a failed Lint check for this test (one of "warn" or "error")
-            severity="warn"
         }
 
         #  === TODO === respect me in the morning (these conf settings are ignored by the plugin)
         blacklist {
-            # Set to true to check for a blacklist wildcard import, regardless of the "disallow" setting
-            disallowBlacklist=true
+            # Set to true to check for a blacklist wildcard import, regardless of the "whitelist" setting
+            checkEnabled=true
             
             # Comma-separated list of packages in the blacklist
             blacklist=["scala.collections.JavaConversions"]
@@ -47,11 +44,16 @@ linter {
     seq {
         # Checks for Seq.contains calls with different types
         contains {
-            # Set to true to check for use of a Seq[A].contains(B) call where A & B are different types
             checkEnabled=true
-
-            # What level of severity to apply to a failed check (one of "warn" or "error")
             severity=warn
         }
+    }
+
+    #
+    # Option.get check  (TODO - is there a broader classification that makes for better organization?)
+    #
+    option.get {
+        checkEnabled=true
+        severity=warn
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,4 +40,18 @@ linter {
             blacklist=["scala.collections.JavaConversions"]
         }
     }
+
+    #
+    # Sequence/Collection related checks
+    #
+    seq {
+        # Checks for Seq.contains calls with different types
+        contains {
+            # Set to true to check for use of a Seq[A].contains(B) call where A & B are different types
+            checkEnabled=true
+
+            # What level of severity to apply to a failed check (one of "warn" or "error")
+            severity=warn
+        }
+    }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,32 @@
+#
+# HOCON-standard Linter configuration to control which Lint checks to run 
+# For syntax help, @see https://github.com/typesafehub/config
+#
+linter {
+
+    #
+    # Wildcard package import control - controls warnings related to importing foo.bar._
+    #
+    package.wildcard {
+
+        whitelist {
+            # Set to true to have linter check and squawk on the use of wildcard imports
+            checkEnabled=true
+            
+            # Comma-separated list of packages to allow for wildcard importing
+            packages=[]
+
+            # What level of severity to apply to a failed Lint check for this test
+            severity="error"
+        }
+
+        #  === TODO === respect me in the morning (these conf settings are ignored by the plugin)
+        blacklist {
+            # Set to true to check for a blacklist wildcard import, regardless of the "disallow" setting
+            disallowBlacklist=true
+            
+            # Comma-separated list of packages in the blacklist
+            blacklist=["scala.collections.JavaConversions"]
+        }
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -16,8 +16,8 @@ linter {
             # Comma-separated list of packages to allow for wildcard importing
             packages=[]
 
-            # What level of severity to apply to a failed Lint check for this test
-            severity="error"
+            # What level of severity to apply to a failed Lint check for this test (one of "warn" or "error")
+            severity="warn"
         }
 
         #  === TODO === respect me in the morning (these conf settings are ignored by the plugin)

--- a/src/main/scala/LinterConfig.scala
+++ b/src/main/scala/LinterConfig.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
  * which are override-able by an including application.</p>
  */
 object LinterConfig {
-  
+
   val config = ConfigFactory.load("linter")
   config.checkValid(ConfigFactory.defaultReference(), "linter")
   

--- a/src/main/scala/LinterConfig.scala
+++ b/src/main/scala/LinterConfig.scala
@@ -1,0 +1,18 @@
+package com.foursquare.lint
+
+import com.typesafe.config.ConfigFactory 
+
+/**
+ * <p>Configuration class for running (or not) different lint checks</p>
+ * <p>As a library, linter defaults to including the src/main/resources/reference.conf settings
+ * which are override-able by an including application.</p>
+ */
+object LinterConfig {
+  
+  val config = ConfigFactory.load("linter")
+  config.checkValid(ConfigFactory.defaultReference(), "linter")
+  
+  val packageWildcardWhitelistCheckEnabled = config.getBoolean("linter.package.wildcard.whitelist.checkEnabled")
+  val packageWildcardWhitelistPackages = config.getStringList("linter.package.wildcard.whitelist.packages")
+  val packageWildcardWhitelistSeverity = LinterSeverity.withName(config.getString("linter.package.wildcard.whitelist.severity"))
+}

--- a/src/main/scala/LinterConfig.scala
+++ b/src/main/scala/LinterConfig.scala
@@ -18,4 +18,7 @@ object LinterConfig {
   val packageWildcardWhitelistCheckEnabled = config.getBoolean("linter.package.wildcard.whitelist.checkEnabled")
   val packageWildcardWhitelistPackages = config.getStringList("linter.package.wildcard.whitelist.packages")
   val packageWildcardWhitelistSeverity = LinterSeverity.withName(config.getString("linter.package.wildcard.whitelist.severity"))
+  
+  val seqContainsCheckEnabled = config.getBoolean("linter.seq.contains.checkEnabled")
+  val seqContainsSeverity = LinterSeverity.withName(config.getString("linter.seq.contains.severity"))
 }

--- a/src/main/scala/LinterConfig.scala
+++ b/src/main/scala/LinterConfig.scala
@@ -21,4 +21,7 @@ object LinterConfig {
   
   val seqContainsCheckEnabled = config.getBoolean("linter.seq.contains.checkEnabled")
   val seqContainsSeverity = LinterSeverity.withName(config.getString("linter.seq.contains.severity"))
+  
+  val optionGetCheckEnabled = config.getBoolean("linter.option.get.checkEnabled")
+  val optionGetSeverity = LinterSeverity.withName(config.getString("linter.option.get.severity"))
 }

--- a/src/main/scala/LinterConfig.scala
+++ b/src/main/scala/LinterConfig.scala
@@ -12,6 +12,9 @@ object LinterConfig {
   val config = ConfigFactory.load("linter")
   config.checkValid(ConfigFactory.defaultReference(), "linter")
   
+  val eqeqCheckEnabled = config.getBoolean("linter.eqeq.checkEnabled")
+  val eqeqSeverity = LinterSeverity.withName(config.getString("linter.eqeq.severity"))
+  
   val packageWildcardWhitelistCheckEnabled = config.getBoolean("linter.package.wildcard.whitelist.checkEnabled")
   val packageWildcardWhitelistPackages = config.getStringList("linter.package.wildcard.whitelist.packages")
   val packageWildcardWhitelistSeverity = LinterSeverity.withName(config.getString("linter.package.wildcard.whitelist.severity"))

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -96,10 +96,11 @@ class LinterPlugin(val global: Global) extends Plugin {
             annotateUnit(pkg.pos, "Wildcard imports should be avoided.  Favor import selector clauses.", packageWildcardWhitelistSeverity)
 
         case Apply(contains @ Select(seq, _), List(target))
-            if methodImplements(contains.symbol, SeqLikeContains) && !(target.tpe <:< SeqMemberType(seq.tpe)) =>
+            if seqContainsCheckEnabled 
+            && methodImplements(contains.symbol, SeqLikeContains) 
+            && !(target.tpe <:< SeqMemberType(seq.tpe)) =>
           val warnMsg = "SeqLike[%s].contains(%s) will probably return false."
-          unit.warning(contains.pos, warnMsg.format(SeqMemberType(seq.tpe), target.tpe.widen))
-          // TODO - use annotateUnit right here
+          annotateUnit(contains.pos, warnMsg.format(SeqMemberType(seq.tpe), target.tpe.widen), seqContainsSeverity)
 
         case get @ Select(_, nme.get) if methodImplements(get.symbol, OptionGet) =>
           if (!get.pos.source.path.contains("src/test")) {

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -92,7 +92,16 @@ class LinterPlugin(val global: Global) extends Plugin {
         
           // TODO - respect the whitelist exceptions
         case Import(pkg, selectors)
-            if packageWildcardWhitelistCheckEnabled && selectors.exists(isGlobalImport) =>
+            if packageWildcardWhitelistCheckEnabled 
+            && selectors.exists(isGlobalImport) 
+            
+            /* For a statement like "import java.util._", 
+               pkg.symbol = "util"
+               pkg.class = class scala.reflect.generic.Trees$Select
+               We need to figure out how to get the "ancestor symbol(s)" of pkg to do string matching on the whole package name
+             
+             && !(packageWildcardWhitelistPackages.contains(pkg.symbol)) */ =>
+            println("The class of pkg is " + pkg.getClass)
             annotateUnit(pkg.pos, "Wildcard imports should be avoided.  Favor import selector clauses.", packageWildcardWhitelistSeverity)
 
         case Apply(contains @ Select(seq, _), List(target))

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -19,7 +19,6 @@ package com.foursquare.lint
 import scala.reflect.generic.Flags
 import scala.tools.nsc.{Global, Phase}
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
-import com.foursquare.lint.LinterConfig._
 
 class LinterPlugin(val global: Global) extends Plugin {
   import global._
@@ -46,6 +45,7 @@ class LinterPlugin(val global: Global) extends Plugin {
     class LinterTraverser(unit: CompilationUnit) extends Traverser {
       import definitions.{AnyClass, ObjectClass, Object_==, OptionClass, SeqClass}
       import LinterSeverity._
+      import LinterConfig._
 
       val JavaConversionsModule: Symbol = definitions.getModule("scala.collection.JavaConversions")
       val SeqLikeClass: Symbol = definitions.getClass("scala.collection.SeqLike")
@@ -114,18 +114,3 @@ class LinterPlugin(val global: Global) extends Plugin {
   }
 }
 
-
-
-/**
- * Enumeration that models the different compile-time notifications Linter
- * can alert the developer to based on configuration of the different
- * types of lint checks.
- * 
- * These severities are a subset of the available notification functions on
- * the @scala.tools.nsc.CompilationUnits$CompilationUnit
- */
-object LinterSeverity extends Enumeration {
-  type LinterSeverity = Value
-  val WARN = Value("warn")
-  val ERROR = Value("error")
-}

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -19,7 +19,6 @@ package com.foursquare.lint
 import scala.reflect.generic.Flags
 import scala.tools.nsc.{Global, Phase}
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
-import com.typesafe.config.ConfigFactory 
 
 class LinterPlugin(val global: Global) extends Plugin {
   import global._
@@ -113,20 +112,6 @@ class LinterPlugin(val global: Global) extends Plugin {
 }
 
 
-/**
- * <p>Configuration class for running (or not) different lint checks</p>
- * <p>As a library, linter defaults to including the src/main/resources/reference.conf settings
- * which are override-able by an including application.</p>
- */
-object LinterConfig {
-  
-  val config = ConfigFactory.load("linter")
-  config.checkValid(ConfigFactory.defaultReference(), "linter")
-  
-  val packageWildcardWhitelistCheckEnabled = config.getBoolean("linter.package.wildcard.whitelist.checkEnabled")
-  val packageWildcardWhitelistPackages = config.getStringList("linter.package.wildcard.whitelist.packages")
-  val packageWildcardWhitelistSeverity = LinterSeverity.withName(config.getString("linter.package.wildcard.whitelist.severity"))
-}
 
 /**
  * Enumeration that models the different compile-time notifications Linter

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -102,11 +102,11 @@ class LinterPlugin(val global: Global) extends Plugin {
           val warnMsg = "SeqLike[%s].contains(%s) will probably return false."
           annotateUnit(contains.pos, warnMsg.format(SeqMemberType(seq.tpe), target.tpe.widen), seqContainsSeverity)
 
-        case get @ Select(_, nme.get) if methodImplements(get.symbol, OptionGet) =>
-          if (!get.pos.source.path.contains("src/test")) {
-            unit.warning(get.pos, "Calling .get on Option will throw an exception if the Option is None.")
-            // TODO - use annotateUnit right here
-          }
+        case get @ Select(_, nme.get) 
+          if optionGetCheckEnabled
+          && methodImplements(get.symbol, OptionGet)
+          && !(get.pos.source.path.contains("src/test")) =>
+            annotateUnit(get.pos, "Calling .get on Option will throw an exception if the Option is None.", optionGetSeverity)
 
         case _ =>
           super.traverse(tree)

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -19,6 +19,7 @@ package com.foursquare.lint
 import scala.reflect.generic.Flags
 import scala.tools.nsc.{Global, Phase}
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import com.foursquare.lint.LinterConfig._
 
 class LinterPlugin(val global: Global) extends Plugin {
   import global._

--- a/src/main/scala/LinterSeverity.scala
+++ b/src/main/scala/LinterSeverity.scala
@@ -1,0 +1,15 @@
+package com.foursquare.lint
+
+/**
+ * Enumeration that models the different compile-time notifications Linter
+ * can alert the developer to based on configuration of the different
+ * types of lint checks.
+ * 
+ * These severities are a subset of the available notification functions on
+ * the @scala.tools.nsc.CompilationUnits$CompilationUnit
+ */
+object LinterSeverity extends Enumeration {
+  type LinterSeverity = Value
+  val WARN = Value("warn")
+  val ERROR = Value("error")
+}


### PR DESCRIPTION
This branch contains the integration with com.typesafe.config to externalize the on/off switches of the different checks we might want to run and to introduce a "Severity" level of the check failure messages.

I ran in to a bit of a wall when actually implementing the whitelist because when the compiler plugin's traverse() method gets handed an "import java.util._" statement (for example), the "pkg" paremeter passed to the Import(pkg, selectors) case statement is actually just the Tree "util", so we gotta figure out how to walk up that Tree and get the complete "java.util" statement so that we can check for its string existing in our List of configured whitelists.
